### PR TITLE
Temporarily revert change that break HA deployment

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -233,6 +233,10 @@ def provision_admin(admin)
     # can result in very sluggish VMs, especially when low on memory
     'increase-SBD-timeout-30s.patch',
 
+    # revert a change to detection mechanism of HAE availability, that
+    # breaks when using the DEPS ISO
+    'barclamp-provisioner-hae-check.patch',
+
     # handy utility for setting up node aliases in Crowbar
     'setup-node-aliases.sh',
 

--- a/vagrant/provisioning/admin/barclamp-provisioner-hae-check.patch
+++ b/vagrant/provisioning/admin/barclamp-provisioner-hae-check.patch
@@ -1,0 +1,25 @@
+From 53fad1f305466427bf8d5f71faa2bc845314d28e Mon Sep 17 00:00:00 2001
+From: Dirk Mueller <dmueller@suse.com>
+Date: Wed, 8 Oct 2014 16:46:55 +0200
+Subject: [PATCH] Tighten check for HAE repos
+
+Just an empty directory is not enough, there should be
+repomd metadata in there. so check for the availability
+of the metadata.
+---
+ chef/cookbooks/provisioner/libraries/repositories.rb | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/chef/cookbooks/provisioner/libraries/repositories.rb b/chef/cookbooks/provisioner/libraries/repositories.rb
+index 3b1e9ac..64734f5 100644
+--- a/chef/cookbooks/provisioner/libraries/repositories.rb
++++ b/chef/cookbooks/provisioner/libraries/repositories.rb
+@@ -48,7 +48,7 @@ def inspect_repos(node)
+           suse_optional_repos.each do |name|
+             repos[name] ||= Mash.new
+             next unless repos[name][:url].nil?
+-            missing ||= !(File.exists? "#{node[:provisioner][:root]}/repos/#{name}")
++            missing ||= !(File.exists? "#{node[:provisioner][:root]}/repos/#{name}/repodata/repomd.xml")
+           end
+ 
+           # set an attribute about missing repos so that cookbooks and crowbar

--- a/vagrant/provisioning/admin/prep-admin.sh
+++ b/vagrant/provisioning/admin/prep-admin.sh
@@ -7,6 +7,7 @@ cd /tmp
 patch -d /opt/dell -p1 < barclamp-network-ignore-eth0.patch
 patch -d /opt/dell -p1 < barclamp-provisioner-nfs-export.patch
 patch -d /opt/dell -p1 < barclamp-pacemaker-ignore-target-role-changes.patch
+patch -d /opt/dell -p1 -R < barclamp-provisioner-hae-check.patch
 
 # Scrap pointless 45 second tcpdump per interface
 sed -i 's/45/1/' /opt/dell/chef/cookbooks/ohai/files/default/plugins/crowbar.rb


### PR DESCRIPTION
https://github.com/crowbar/barclamp-provisioner/pull/351 breaks the
detection of availability of HAE repos when using the DEPS ISO.
